### PR TITLE
[Cosmetics] format data function name

### DIFF
--- a/src/modules/market.ts
+++ b/src/modules/market.ts
@@ -1,5 +1,5 @@
 import { Base } from './base';
-import { fromatData } from '../util'
+import { formatData } from '../util'
 
 export class Market extends Base {
   /**
@@ -22,7 +22,7 @@ export class Market extends Base {
 
     const res = this.publicRequest("GET", "/exchangeInfo", options);
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -47,7 +47,7 @@ export class Market extends Base {
     );
 
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -72,7 +72,7 @@ export class Market extends Base {
     );
 
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -97,7 +97,7 @@ export class Market extends Base {
     );
 
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -126,7 +126,7 @@ export class Market extends Base {
     );
 
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -154,7 +154,7 @@ export class Market extends Base {
       })
     );
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -167,7 +167,7 @@ export class Market extends Base {
   avgPrice(symbol: string) {
     const res = this.publicRequest("GET", "/avgPrice", { symbol: symbol.toUpperCase() });
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -184,7 +184,7 @@ export class Market extends Base {
 
     const res = this.publicRequest("GET", "/ticker/24hr", { symbol });
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -201,7 +201,7 @@ export class Market extends Base {
     
     const res = this.publicRequest("GET", "/ticker/price", { symbol });
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }
@@ -217,7 +217,7 @@ export class Market extends Base {
 
     const res = this.publicRequest("GET", "/ticker/bookTicker", { symbol });
     const rawData = JSON.parse(res.getBody());
-    const formatDatas = fromatData(rawData);
+    const formatDatas = formatData(rawData);
 
     return formatDatas;
   }

--- a/src/modules/trade.ts
+++ b/src/modules/trade.ts
@@ -1,5 +1,5 @@
 import { UserData } from './userData';
-import { fromatData } from '../util'
+import { formatData } from '../util'
 
 export class Trade extends UserData {
     /**
@@ -39,7 +39,7 @@ export class Trade extends UserData {
             type: orderType.toUpperCase()
         }))
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }
@@ -81,7 +81,7 @@ export class Trade extends UserData {
             type: orderType.toUpperCase()
         }))
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }
@@ -103,7 +103,7 @@ export class Trade extends UserData {
             symbol: symbol.toUpperCase()
         }))
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }
@@ -119,7 +119,7 @@ export class Trade extends UserData {
             symbol: symbol.toUpperCase()
         })
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }
@@ -140,7 +140,7 @@ export class Trade extends UserData {
             symbol: symbol.toUpperCase()
         }))
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }
@@ -154,7 +154,7 @@ export class Trade extends UserData {
     public openOrders(symbol: string) {
         const res = this.signRequest('GET', '/openOrders', { symbol: symbol.toUpperCase()})
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }
@@ -177,7 +177,7 @@ export class Trade extends UserData {
             symbol: symbol.toUpperCase()
         }))
         const rawData = JSON.parse(res.getBody());
-        const formatDatas = fromatData(rawData);
+        const formatDatas = formatData(rawData);
     
         return formatDatas;
     }

--- a/src/modules/userData.ts
+++ b/src/modules/userData.ts
@@ -1,5 +1,5 @@
 import { Common } from './common';
-import { fromatData } from '../util'
+import { formatData } from '../util'
 
 export class UserData extends Common {
     /**
@@ -10,7 +10,7 @@ export class UserData extends Common {
     public accountInfo() {
       const res = this.signRequest ('GET', '/account')
       const rawData = JSON.parse(res.getBody());
-      const formatDatas = fromatData(rawData);
+      const formatDatas = formatData(rawData);
   
       return formatDatas;
     }
@@ -35,7 +35,7 @@ export class UserData extends Common {
         symbol: symbol.toUpperCase()
       }))
       const rawData = JSON.parse(res.getBody());
-      const formatDatas = fromatData(rawData);
+      const formatDatas = formatData(rawData);
   
       return formatDatas;
     }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -33,14 +33,14 @@ const buildQueryString = (params: any) => {
       .join('&')
 }
 
-const fromatData = (datas: any): any => {
+const formatData = (datas: any): any => {
     if(Array.isArray(datas)) {
         return datas.map((data: any) => {
-            return fromatData(data)
+            return formatData(data)
         })
     } else if (typeof datas === "object" && datas !== null) {
             const newObj: any = {}
-            Object.entries(datas).map(([key, value]: any[]) => newObj[key] = fromatData(value))
+            Object.entries(datas).map(([key, value]: any[]) => newObj[key] = formatData(value))
             return newObj;
     } else {
         return (datas === undefined || datas === null) ? "" : datas
@@ -52,5 +52,5 @@ export {
     buildQueryString,
     removeEmptyValue,
     isEmptyValue,
-    fromatData
+    formatData
 }


### PR DESCRIPTION
This pull request addresses a minor but crucial typo in the function name fromatData, correcting it to formatData. The change ensures the function name accurately reflects its intended operation, enhancing code readability and maintainability. No functionality alterations are made, guaranteeing seamless integration with existing codebases.