### PR TITLE
Erro on publicRequest header with X-MEXC-APIKEY

### DIFF
--- a/src/modules/base.ts
+++ b/src/modules/base.ts
@@ -21,8 +21,7 @@ export class Base {
       baseURL: this.config.baseURL,
       url: path,
       headers: {
-        'Content-Type': 'application/json',
-        'X-MEXC-APIKEY': this.config.apiKey
+        'Content-Type': 'application/json'
       }
     })
   }


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `mexc-api-sdk@1.0.3` for the project I'm working on.

<!-- 🔺️🔺️🔺️ PLEASE REPLACE THIS BLOCK with a description of your problem, and any other relevant context 🔺️🔺️🔺️ -->

Here is the diff that solved my problem:

```diff
diff --git a/node_modules/mexc-api-sdk/src/modules/base.js b/node_modules/mexc-api-sdk/src/modules/base.js
index 7a23d2a..d6dfc0f 100644
--- a/node_modules/mexc-api-sdk/src/modules/base.js
+++ b/node_modules/mexc-api-sdk/src/modules/base.js
@@ -35,8 +35,7 @@ class Base {
             baseURL: this.config.baseURL,
             url: path,
             headers: {
-                'Content-Type': 'application/json',
-                'X-MEXC-APIKEY': this.config.apiKey
+                'Content-Type': 'application/json'
             }
         });
     }
```

<em>This issue body was [partially generated by patch-package](https://github.com/ds300/patch-package/issues/296).</em>
